### PR TITLE
docs(issues): remove `Meta` sections from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,10 +12,8 @@ Notes:
 1. Only post _bug reports_ here.
 2. Use the appropriate template for _feature requests_.
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
-
-Please suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
-
-* https://github.com/saltstack-formulas/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
+4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
+  - https://github.com/saltstack-formulas/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
 -->
 
 ## Your setup

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,10 @@ Notes:
 1. Only post _bug reports_ here.
 2. Use the appropriate template for _feature requests_.
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
+
+Please suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
+
+* https://github.com/saltstack-formulas/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
 -->
 
 ## Your setup
@@ -57,12 +61,5 @@ Notes:
 
 ### Additional context
 <!-- Add any other context about the problem here. -->
-
-
-
----
-
-### Meta: How can this template be improved?
-<!-- Feel free to suggest how this template can be improved. -->
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,10 +12,8 @@ Notes:
 1. Only post _feature requests_ here.
 2. Use the appropriate template for _bug reports_.
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
-
-Please suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
-
-* https://github.com/saltstack-formulas/.github/blob/master/.github/ISSUE_TEMPLATE/feature_request.md
+4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
+  - https://github.com/saltstack-formulas/.github/blob/master/.github/ISSUE_TEMPLATE/feature_request.md
 -->
 
 ### Is your feature request related to a problem?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,6 +12,10 @@ Notes:
 1. Only post _feature requests_ here.
 2. Use the appropriate template for _bug reports_.
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
+
+Please suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
+
+* https://github.com/saltstack-formulas/.github/blob/master/.github/ISSUE_TEMPLATE/feature_request.md
 -->
 
 ### Is your feature request related to a problem?
@@ -31,12 +35,5 @@ Notes:
 
 ### Additional context
 <!-- Add any other context about the feature request here. -->
-
-
-
----
-
-### Meta: How can this template be improved?
-<!-- Feel free to suggest how this template can be improved. -->
 
 


### PR DESCRIPTION
* Replace with a link to each template, to encourage issues/PRs instead