### PR TITLE
feat(safe-settings): add Admin PR approvals and restrict formula settings to managed formulas

### DIFF
--- a/admin-safe-settings/suborgs/baseline.yml
+++ b/admin-safe-settings/suborgs/baseline.yml
@@ -58,3 +58,19 @@ rulesets:
             - context: Release / Collect results
               integration_id: 15368
           strict_required_status_checks_policy: false
+  - name: Require PR approvals before updating the default branch
+    target: branch
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+        exclude: []
+    rules:
+      - type: pull_request
+        parameters:
+          dismiss_stale_reviews_on_push: false
+          require_code_owner_review: false
+          require_last_push_approval: true
+          required_approving_review_count: 1
+          required_review_thread_resolution: true

--- a/admin-safe-settings/suborgs/baseline.yml
+++ b/admin-safe-settings/suborgs/baseline.yml
@@ -20,6 +20,17 @@ environments:
       - name: SAFE_SETTINGS_APP_ID
         value: '3020872'
 
+repository:
+  # As we use `semantic-release` throughout the formulas, which means every
+  # commit message is important, we disallow squash merging so that commit
+  # messages are not inadvertently destroyed.
+  # In addition, Renovate defaults to squash merging unless the repository
+  # settings disallows it.
+  allow_squash_merge: false
+
+  # Allow auto-merging to allow Renovate to work more efficiently
+  allow_auto_merge: true
+
 rulesets:
   - name: Prevent destruction of the default branch
     target: branch

--- a/formula-safe-settings/deployment-settings.yml
+++ b/formula-safe-settings/deployment-settings.yml
@@ -1,0 +1,9 @@
+restrictedRepos:
+  include:
+    - nginx-formula
+    - openssh-formula
+    - postfix-formula
+    - salt-formula
+    - syslog-ng-formula
+    - template-formula
+    - vault-formula


### PR DESCRIPTION
- **feat(admin-safe-settings): add auto-merge settings**
- **feat(admin-safe-settings): add rule to require 1 approval for all PRs**
- **fix(formula-safe-settings): apply formula settings only to currently-managed formulas**
